### PR TITLE
fix: pass numbers to prom-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.2",
-    "@libp2p/interface-metrics": "^4.0.0",
+    "@libp2p/interface-metrics": "^4.0.2",
     "@libp2p/logger": "^2.0.2",
     "it-foreach": "^1.0.0",
     "it-stream-types": "^1.0.4"

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -18,7 +18,7 @@ export class PrometheusCounter implements Counter {
       collect = async function () {
         const value = await calculate()
 
-        this.inc(Number(value))
+        this.inc(value)
       }
     }
 
@@ -30,10 +30,8 @@ export class PrometheusCounter implements Counter {
     })
   }
 
-  increment (value: number | bigint = 1): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.counter.inc(Number(value))
+  increment (value: number = 1): void {
+    this.counter.inc(value)
   }
 
   reset (): void {

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -18,9 +18,7 @@ export class PrometheusMetric implements Metric {
       collect = async function () {
         const value = await calculate()
 
-        // prom-client does not support bigints for values
-        // https://github.com/siimon/prom-client/issues/259
-        this.set(Number(value))
+        this.set(value)
       }
     }
 
@@ -32,22 +30,16 @@ export class PrometheusMetric implements Metric {
     })
   }
 
-  update (value: number | bigint): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.gauge.set(Number(value))
+  update (value: number): void {
+    this.gauge.set(value)
   }
 
-  increment (value: number | bigint = 1): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.gauge.inc(Number(value))
+  increment (value: number = 1): void {
+    this.gauge.inc(value)
   }
 
-  decrement (value: number | bigint = 1): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.gauge.dec(Number(value))
+  decrement (value: number = 1): void {
+    this.gauge.dec(value)
   }
 
   reset (): void {


### PR DESCRIPTION
bigints are not in the interface any more, only numbers will be passed so just pass them straight through to prom-client.