### PR TITLE
fix: pass numbers to prom-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.2",
-    "@libp2p/interface-metrics": "^4.0.0",
+    "@libp2p/interface-metrics": "^4.0.2",
     "@libp2p/logger": "^2.0.2",
     "it-foreach": "^1.0.0",
     "it-stream-types": "^1.0.4"

--- a/src/counter.ts
+++ b/src/counter.ts
@@ -18,7 +18,7 @@ export class PrometheusCounter implements Counter {
       collect = async function () {
         const value = await calculate()
 
-        this.inc(Number(value))
+        this.inc(value)
       }
     }
 
@@ -30,10 +30,8 @@ export class PrometheusCounter implements Counter {
     })
   }
 
-  increment (value: number | bigint = 1): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.counter.inc(Number(value))
+  increment (value: number = 1): void {
+    this.counter.inc(value)
   }
 
   reset (): void {

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -18,9 +18,7 @@ export class PrometheusMetric implements Metric {
       collect = async function () {
         const value = await calculate()
 
-        // prom-client does not support bigints for values
-        // https://github.com/siimon/prom-client/issues/259
-        this.set(Number(value))
+        this.set(value)
       }
     }
 
@@ -32,22 +30,16 @@ export class PrometheusMetric implements Metric {
     })
   }
 
-  update (value: number | bigint): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.gauge.set(Number(value))
+  update (value: number): void {
+    this.gauge.set(value)
   }
 
-  increment (value: number | bigint = 1): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.gauge.inc(Number(value))
+  increment (value: number = 1): void {
+    this.gauge.inc(value)
   }
 
-  decrement (value: number | bigint = 1): void {
-    // prom-client does not support bigints for values
-    // https://github.com/siimon/prom-client/issues/259
-    this.gauge.dec(Number(value))
+  decrement (value: number = 1): void {
+    this.gauge.dec(value)
   }
 
   reset (): void {

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -1,24 +1,28 @@
-import type { Metric, CalculatedMetricOptions, StopTimer } from '@libp2p/interface-metrics'
+import type { Metric, CalculatedMetricOptions, StopTimer, CalculateMetric } from '@libp2p/interface-metrics'
 import { CollectFunction, Gauge } from 'prom-client'
 import { normaliseString } from './utils.js'
 
 export class PrometheusMetric implements Metric {
   private readonly gauge: Gauge
+  private readonly calculators: CalculateMetric[]
 
   constructor (name: string, opts: CalculatedMetricOptions) {
     name = normaliseString(name)
     const help = normaliseString(opts.help ?? name)
     const labels = opts.label != null ? [normaliseString(opts.label)] : []
     let collect: CollectFunction<Gauge<any>> | undefined
+    this.calculators = []
 
     // calculated metric
     if (opts?.calculate != null) {
-      const calculate = opts.calculate
+      this.calculators.push(opts.calculate)
+      const self = this
 
       collect = async function () {
-        const value = await calculate()
+        const values = await Promise.all(self.calculators.map(async calculate => await calculate()))
+        const sum = values.reduce((acc, curr) => acc + curr, 0)
 
-        this.set(value)
+        this.set(sum)
       }
     }
 
@@ -28,6 +32,10 @@ export class PrometheusMetric implements Metric {
       labelNames: labels,
       collect
     })
+  }
+
+  addCalculator (calculator: CalculateMetric) {
+    this.calculators.push(calculator)
   }
 
   update (value: number): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,8 @@
+import type { CalculateMetric } from '@libp2p/interface-metrics'
+
+export interface CalculatedMetric <T = number> {
+  addCalculator: (calculator: CalculateMetric<T>) => void
+}
 
 export const ONE_SECOND = 1000
 export const ONE_MINUTE = 60 * ONE_SECOND

--- a/test/counters.spec.ts
+++ b/test/counters.spec.ts
@@ -64,4 +64,22 @@ describe('counters', () => {
 
     await expect(client.register.metrics()).to.eventually.include(`${metricName} 0`, 'did not include updated metric')
   })
+
+  it('should allow use of the same counter from multiple reporters', async () => {
+    const metricName = randomMetricName()
+    const metricLabel = randomMetricName('label_')
+    const metricValue1 = 5
+    const metricValue2 = 7
+    const metrics = prometheusMetrics()()
+    const metric1 = metrics.registerCounter(metricName, {
+      label: metricLabel
+    })
+    metric1.increment(metricValue1)
+    const metric2 = metrics.registerCounter(metricName, {
+      label: metricLabel
+    })
+    metric2.increment(metricValue2)
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue1 + metricValue2}`)
+  })
 })

--- a/test/metric-groups.spec.ts
+++ b/test/metric-groups.spec.ts
@@ -137,4 +137,31 @@ describe('metric groups', () => {
 
     await expect(client.register.metrics()).to.eventually.not.include(metricKey, 'still included metric key')
   })
+
+  it('should allow use of the same metric group from multiple reporters', async () => {
+    const metricName = randomMetricName()
+    const metricKey1 = randomMetricName('key_')
+    const metricKey2 = randomMetricName('key_')
+    const metricLabel = randomMetricName('label_')
+    const metricValue1 = 5
+    const metricValue2 = 7
+    const metrics = prometheusMetrics()()
+    const metric1 = metrics.registerMetricGroup(metricName, {
+      label: metricLabel
+    })
+    metric1.update({
+      [metricKey1]: metricValue1
+    })
+    const metric2 = metrics.registerMetricGroup(metricName, {
+      label: metricLabel
+    })
+    metric2.update({
+      [metricKey2]: metricValue2
+    })
+
+    const reportedMetrics = await client.register.metrics()
+
+    expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey1}"} ${metricValue1}`, 'did not include updated metric')
+    expect(reportedMetrics).to.include(`${metricName}{${metricLabel}="${metricKey2}"} ${metricValue2}`, 'did not include updated metric')
+  })
 })

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -93,4 +93,22 @@ describe('metrics', () => {
 
     await expect(client.register.metrics()).to.eventually.include(`${metricName} 0`, 'did not include updated metric')
   })
+
+  it('should allow use of the same metric from multiple reporters', async () => {
+    const metricName = randomMetricName()
+    const metricLabel = randomMetricName('label_')
+    const metricValue1 = 5
+    const metricValue2 = 7
+    const metrics = prometheusMetrics()()
+    const metric1 = metrics.registerMetric(metricName, {
+      label: metricLabel
+    })
+    metric1.update(metricValue1)
+    const metric2 = metrics.registerMetric(metricName, {
+      label: metricLabel
+    })
+    metric2.update(metricValue2)
+
+    await expect(client.register.metrics()).to.eventually.include(`${metricName} ${metricValue2}`)
+  })
 })


### PR DESCRIPTION
bigints are not in the interface any more, only numbers will be passed
so just pass them straight through to prom-client.