### PR TITLE
fix: use collectDefaultMetrics option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ class PrometheusMetrics implements Metrics {
       register.clear()
     }
 
-    if (init?.preserveExistingMetrics !== false) {
+    if (init?.collectDefaultMetrics !== false) {
       log('Collecting default metrics')
       collectDefaultMetrics(init?.defaultMetrics)
     }


### PR DESCRIPTION
For apps that make heavy use of prometheus metrics, it may be possible that the default metrics are already registered and managed and configured separately. This is the case in lodestar.

Feature to disable default metrics